### PR TITLE
feat: graceful shutdown on Ctrl+C (finish current job first)

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,5 +1,5 @@
 const { Worker, Queue, QueueEvents, QueueScheduler } = require('bullmq');
-const { exec } = require('child_process');
+const { spawn } = require('child_process');
 const axios = require('axios');
 
 require('dotenv').config();
@@ -12,18 +12,20 @@ const conn = {
     }
 };
 
+// Tracks the currently running job.sh child so a forced shutdown can kill it.
+let currentChild = null;
+
 const worker = new Worker('xdio', async job => {
     console.log(`# Job started: ${job.id}`, job.data);
     return new Promise((resolve, reject) => {
 
-        // let time = 0;
-        let child = exec('./job.sh ' + job.data.hash, (error, stdout, stderr) => {
-            if (error) {
-                console.error(`Execution error: ${error}`);
-                reject(error);
-            }
-            resolve({ 'status': 0 });
-        });
+        // Spawn job.sh in its own process group (detached) so a Ctrl+C sent to
+        // this worker's group does NOT kill the in-progress transcription.
+        // That lets worker.close() wait for the job to finish gracefully.
+        // (exec ignores `detached` for process-group purposes, so we use spawn;
+        // the argument array also avoids shell interpretation of the hash.)
+        let child = spawn('./job.sh', [job.data.hash], { detached: true });
+        currentChild = child;
 
         child.stdout.setEncoding('utf8');
         child.stdout.on('data', function (data) {
@@ -45,6 +47,21 @@ const worker = new Worker('xdio', async job => {
 
         });
 
+        child.on('error', function (error) {
+            currentChild = null;
+            console.error(`Execution error: ${error}`);
+            reject(error);
+        });
+
+        child.on('close', function (code, signal) {
+            currentChild = null;
+            if (code === 0) {
+                resolve({ 'status': 0 });
+            } else {
+                reject(new Error(`job.sh exited with code ${code}${signal ? ` (signal ${signal})` : ''}`));
+            }
+        });
+
     });
 }, conn);
 
@@ -60,10 +77,26 @@ worker.on('error', (err) => {
     console.log(`# Worker error: ${err.message}`);
 })
 
-process.on('SIGINT', async () => {
-    console.log('** Received SIGINT. The process will terminate (gracefully) after the current job.');
-    await worker.close();
+let shuttingDown = false;
+
+async function shutdown(signal) {
+    if (shuttingDown) {
+        // Second interrupt: the user is impatient — kill the running job's
+        // whole process group and exit immediately.
+        console.log(`** ${signal} again — forcing shutdown now.`);
+        if (currentChild) {
+            try { process.kill(-currentChild.pid, 'SIGKILL'); } catch (err) { /* already gone */ }
+        }
+        process.exit(1);
+    }
+
+    shuttingDown = true;
+    console.log(`** Received ${signal}. Finishing the current job, then stopping. Press Ctrl+C again to force quit.`);
+    await worker.close(); // stops fetching new jobs and waits for the active one to finish
     process.exit(0);
-});
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
 
 console.log("Worker is running and waiting for jobs.");


### PR DESCRIPTION
## Problem

Pressing **Ctrl+C** while running \`npm run work\` killed the in-progress transcription immediately instead of letting it finish.

**Root cause:** Ctrl+C sends SIGINT to the entire foreground *process group*. The existing \`SIGINT\` handler already called \`worker.close()\` (which is meant to wait for the active job), but \`job.sh\` — and its \`ffmpeg\`/\`whisper-cli\` children — ran in that same group and were killed by the same Ctrl+C. So the job was already dead before \`worker.close()\` could wait for it.

## Fix

- Spawn \`job.sh\` **detached** (in its own process group) so a group-directed Ctrl+C no longer reaches it.
- The worker catches \`SIGINT\`/\`SIGTERM\` alone, stops accepting new jobs, and \`worker.close()\` waits for the running job to finish before exiting.
- **Second Ctrl+C** force-kills the job's process group (\`process.kill(-pid, 'SIGKILL')\`) and exits immediately.
- Switched \`exec\` → \`spawn\`: \`exec\` ignores the \`detached\` option for process-group purposes (verified on macOS/Node 24 — the child stayed in the parent group), so the fix requires \`spawn\`. The argument array also removes the shell-injection risk from interpolating the job hash.

## Verification

Full Redis + xdio API loop can't run in CI, so the mechanism was verified with standalone harnesses:

- Process-group mechanism (4/4 pass): detached child is its own group leader, differs from the worker group, a non-detached child shares it, and \`process.kill(-pid, SIGKILL)\` terminates the detached group.
- End-to-end SIGINT simulation: with the fix, the job survives a real group-directed Ctrl+C and completes (exit 0); the old attached behavior dies on SIGINT (exit 1), reproducing the original symptom.

## Note for reviewer / testing

Since the worker is launched via \`npm run work\`, both \`npm\` and \`node\` receive the Ctrl+C. \`node\` drains correctly either way (the transcription is detached and safe), but \`npm\` may return the shell prompt slightly before \`node\` fully exits. Running \`node client.js\` directly keeps the terminal attached until it's truly done. Worth confirming during a real end-to-end run.