### PR TITLE
fix: prevent 'could not renew lock' on long transcription jobs

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,4 +1,4 @@
-const { Worker, Queue, QueueEvents, QueueScheduler } = require('bullmq');
+const { Worker } = require('bullmq');
 const { spawn } = require('child_process');
 const axios = require('axios');
 
@@ -9,7 +9,15 @@ const conn = {
         host: process.env.REDIS_HOST,
         port: process.env.REDIS_PORT,
         password: process.env.REDIS_AUTH
-    }
+    },
+    // Transcriptions run for minutes; the default 30s lock is far too short and
+    // gets lost during long jobs -> "could not renew lock". The worker renews
+    // every lockDuration/2, so a 5-minute lock leaves ample slack even when the
+    // event loop is briefly busy. maxStalledCount is a backstop: re-running a
+    // job is safe (the /v2/whisper/done endpoint no-ops once a job is done).
+    lockDuration: 300000,     // 5 min
+    stalledInterval: 300000,  // check for stalled jobs every 5 min
+    maxStalledCount: 3,
 };
 
 // Tracks the currently running job.sh child so a forced shutdown can kill it.
@@ -17,6 +25,12 @@ let currentChild = null;
 
 const worker = new Worker('xdio', async job => {
     console.log(`# Job started: ${job.id}`, job.data);
+    // Only push a progress update when the whole-percent value actually changes.
+    // whisper's -pp callback emits progress constantly; calling updateProgress on
+    // every chunk floods the Redis connection the lock renewal shares, which is a
+    // direct contributor to lost locks.
+    let lastPct = -1;
+
     return new Promise((resolve, reject) => {
 
         // Spawn job.sh in its own process group (detached) so a Ctrl+C sent to
@@ -42,7 +56,10 @@ const worker = new Worker('xdio', async job => {
 
             if (match_progress) {
                 const percentage = parseInt(match_progress[1], 10);
-                job.updateProgress(percentage);
+                if (percentage !== lastPct) {
+                    lastPct = percentage;
+                    job.updateProgress(percentage);
+                }
             }
 
         });


### PR DESCRIPTION
## Problem

The worker intermittently logs `# Worker error: could not renew lock for job N`.

BullMQ (5.56) holds a **lock** on the active job and renews it every ~half of `lockDuration` on the Node event loop. The default `lockDuration` is **30 s**, but whisper transcriptions run for **minutes**. Two things caused the 30 s lock to expire before renewal:

1. `job.sh` runs `whisper-cli -pp`, which emits progress to stderr **constantly**.
2. The stderr handler called `job.updateProgress()` on **every** chunk — a Redis write on the **same connection** the lock renewal uses. Hundreds of these flood the connection and delay the renewal timer past the 30 s lock → lock lost → `could not renew lock`. A lost lock also marks the job **stalled**, which triggers **redundant re-transcriptions**.

## Fix

- **`lockDuration: 300000` (5 min)** + `stalledInterval: 300000` + `maxStalledCount: 3`. The renewal only needs to succeed every 2.5 min, so brief event-loop busyness no longer loses the lock. `maxStalledCount` is a backstop — re-running a job is safe (`/v2/whisper/done` no-ops once a job is done).
- **Throttle `updateProgress`** to fire only when the whole-percent value changes (was: every stderr chunk) — stops congesting the Redis connection.
- Drop the dead `QueueScheduler`/`Queue`/`QueueEvents` imports (`QueueScheduler` was removed in BullMQ v4; only `Worker` is used).

## Testing

- `node --check client.js` passes.
- Behavioural: run the worker against a real long job — the `could not renew lock` error should no longer appear, progress still updates (once per percent), and Ctrl+C graceful shutdown is unchanged.